### PR TITLE
Add a button to open an existing file of any type

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -120,9 +120,15 @@ fun BeauTyXTApp(
             composable(route = BeauTyXTScreens.Start.name) {
                 StartupScreen(
                     modifier = modifier,
-                    onOpenButtonClicked = {
+                    onOpenTxtButtonClicked = {
                         openFileLauncher.launch(
                             arrayOf("text/plain"),
+                            ActivityOptionsCompat.makeBasic(),
+                        )
+                    },
+                    onOpenAnyButtonClicked = {
+                        openFileLauncher.launch(
+                            arrayOf("*/*"),
                             ActivityOptionsCompat.makeBasic(),
                         )
                     },

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/StartupScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/StartupScreen.kt
@@ -34,7 +34,8 @@ import dev.soupslurpr.beautyxt.R
 @Composable
 fun StartupScreen(
     modifier: Modifier,
-    onOpenButtonClicked: () -> Unit,
+    onOpenTxtButtonClicked: () -> Unit,
+    onOpenAnyButtonClicked: () -> Unit,
     onCreateButtonClicked: () -> Unit,
     onSettingsButtonClicked: () -> Unit,
 ) {
@@ -56,19 +57,30 @@ fun StartupScreen(
             style = MaterialTheme.typography.headlineLarge
         )
         Text(
-            text = "Text, but beautiful.",
+            text = "3 releases in one day?!",
             style = MaterialTheme.typography.bodySmall
         )
         FilledTonalButton(
             modifier = modifier.fillMaxWidth(),
-            onClick = { onOpenButtonClicked() }
+            onClick = { onOpenTxtButtonClicked() }
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.baseline_file_open_24),
                 contentDescription = null
             )
             Spacer(modifier = modifier.width(8.dp))
-            Text(stringResource(R.string.open_existing_file))
+            Text(stringResource(R.string.open_existing_txt_file))
+        }
+        FilledTonalButton(
+            modifier = modifier.fillMaxWidth(),
+            onClick = { onOpenAnyButtonClicked() }
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.baseline_file_open_24),
+                contentDescription = null
+            )
+            Spacer(modifier = modifier.width(8.dp))
+            Text(stringResource(R.string.open_existing_file_of_any_type))
         }
         FilledTonalButton(
             modifier = modifier.fillMaxWidth(),
@@ -100,7 +112,8 @@ fun StartupScreen(
 fun StartupPreview() {
     StartupScreen(
         modifier = Modifier.fillMaxSize(),
-        onOpenButtonClicked = {},
+        onOpenTxtButtonClicked = {},
+        onOpenAnyButtonClicked = {},
         onCreateButtonClicked = {},
         onSettingsButtonClicked = {},
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="back_button">Back</string>
     <string name="welcome">Welcome to BeauTyXT!</string>
     <string name="create_new_file">Create a new file</string>
-    <string name="open_existing_file">Open an existing file</string>
+    <string name="open_existing_txt_file">Open an existing .txt file</string>
     <string name="file_editor">File Editor</string>
     <string name="view_source_code_setting_name">Source code</string>
     <string name="view_source_code_setting_description">View BeauTyXT\'s source code on the GitHub website in your web browser</string>
@@ -17,4 +17,5 @@
     <string name="credits">Credits</string>
     <string name="credits_setting_name">Credits</string>
     <string name="credits_setting_description">View open source licenses of code that BeauTyXT uses in app</string>
+    <string name="open_existing_file_of_any_type">Open an existing file of any type</string>
 </resources>


### PR DESCRIPTION
We can now open any type of file, while still keeping the button to open and show .txt files only. fixes #3