### PR TITLE
Open other file types compatible with text

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -122,7 +122,11 @@ fun BeauTyXTApp(
                     modifier = modifier,
                     onOpenButtonClicked = {
                         openFileLauncher.launch(
-                            arrayOf("text/plain"),
+                            arrayOf(
+                                "text/*",
+                                "application/xml",
+                                "application/json",
+                            ),
                             ActivityOptionsCompat.makeBasic(),
                         )
                     },


### PR DESCRIPTION
This lets us open and edit text compatible file types such as .md, .js, .css, .html, .xml, and .json, but NOT render/compile them.

Fixes #3