### PR TITLE
Make "Text (.txt)" button only open .txt files.

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -137,9 +137,7 @@ fun BeauTyXTApp(
                     onOpenTxtButtonClicked = {
                         openFileLauncher.launch(
                             arrayOf(
-                                "text/*",
-                                "application/xml",
-                                "application/json",
+                                "text/plain"
                             ),
                             ActivityOptionsCompat.makeBasic(),
                         )


### PR DESCRIPTION
Previously it could open various files such as .md, .vcf, and others.