### PR TITLE
Add Settings infrastructure and pitch black background setting

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.22" />
+    <option name="version" value="1.8.21" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "dev.soupslurpr.beautyxt"
-    compileSdkPreview = "UpsideDownCake"
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "dev.soupslurpr.beautyxt"
@@ -51,6 +51,11 @@ android {
                 "proguard-rules.pro"
             )
         }
+        getByName("debug") {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+            signingConfig = signingConfigs.getByName("debug")
+        }
     }
 }
 
@@ -67,4 +72,5 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.7.0-beta01")
     implementation("androidx.datastore:datastore-preferences:1.0.0")
     implementation("androidx.compose.material:material:1.6.0-alpha01")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -24,11 +24,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityOptionsCompat
+import androidx.datastore.core.DataStore
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import dev.soupslurpr.beautyxt.settings.SettingsViewModel
 import dev.soupslurpr.beautyxt.ui.CreditsScreen
 import dev.soupslurpr.beautyxt.ui.FileEditScreen
 import dev.soupslurpr.beautyxt.ui.FileViewModel
@@ -75,9 +77,11 @@ fun BeauTyXTAppBar(
 
 @Composable
 fun BeauTyXTApp(
-    viewModel: FileViewModel = viewModel(),
+    fileViewModel: FileViewModel = viewModel(),
+    settingsViewModel: SettingsViewModel = viewModel(),
     modifier: Modifier,
     intent: Intent,
+    dataStore: DataStore<androidx.datastore.preferences.core.Preferences>
 ) {
     val navController = rememberNavController()
 
@@ -89,18 +93,18 @@ fun BeauTyXTApp(
 
     val context = LocalContext.current
 
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by fileViewModel.uiState.collectAsState()
 
     val openFileLauncher = rememberLauncherForActivityResult(contract = OpenDocument()) {
         if (it != null) {
-            viewModel.setUri(it, context)
+            fileViewModel.setUri(it, context)
             navController.navigate(BeauTyXTScreens.FileEdit.name)
         }
     }
 
     val createFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument("text/plain")) {
         if (it != null) {
-            viewModel.setUri(it, context)
+            fileViewModel.setUri(it, context)
             navController.navigate(BeauTyXTScreens.FileEdit.name)
         }
     }
@@ -109,7 +113,7 @@ fun BeauTyXTApp(
         if (intent.action == Intent.ACTION_VIEW || intent.action == Intent.ACTION_EDIT) {
             val uri: Uri? = intent.data
             if (uri != null) {
-                viewModel.setUri(uri, context)
+                fileViewModel.setUri(uri, context)
                 navController.navigate(BeauTyXTScreens.FileEdit.name)
             }
         }
@@ -170,8 +174,8 @@ fun BeauTyXTApp(
                     content = uiState.content.value,
                     name = uiState.name,
                     onContentChanged = {
-                        viewModel.updateContent(it)
-                        viewModel.setContentToUri(uri = uiState.uri, context = context)
+                        fileViewModel.updateContent(it)
+                        fileViewModel.setContentToUri(uri = uiState.uri, context = context)
                     },
                 )
             }
@@ -185,7 +189,9 @@ fun BeauTyXTApp(
                     },
                     onCreditsIconButtonClicked = {
                         navController.navigate(BeauTyXTScreens.Credits.name)
-                    }
+                    },
+                    dataStore = dataStore,
+                    settingsViewModel = settingsViewModel
                 )
             }
             composable(route = BeauTyXTScreens.License.name) {

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -1,19 +1,33 @@
 package dev.soupslurpr.beautyxt
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.ui.Modifier
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.viewmodel.compose.viewModel
+import dev.soupslurpr.beautyxt.settings.SettingsViewModel
 import dev.soupslurpr.beautyxt.ui.theme.BeauTyXTTheme
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent {
-            BeauTyXTTheme {
+        setContent() {
+            val settingsViewModel: SettingsViewModel = viewModel()
+            BeauTyXTTheme(
+                dataStore = dataStore,
+                settingsViewModel = settingsViewModel
+            ) {
                 BeauTyXTApp(
                     modifier = Modifier,
-                    intent = intent
+                    intent = intent,
+                    dataStore = dataStore,
+                    settingsViewModel = settingsViewModel
                 )
             }
         }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/SettingsUiState.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/SettingsUiState.kt
@@ -1,0 +1,11 @@
+package dev.soupslurpr.beautyxt.settings
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.Preferences
+
+data class SettingsUiState(
+    /** Pair of pitch black background preference key and default boolean value */
+    var pitchBlackBackground: Pair<Preferences.Key<Boolean>, MutableState<Boolean>> = Pair((booleanPreferencesKey("PITCH_BLACK_BACKGROUND")), mutableStateOf(false))
+)

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/SettingsViewModel.kt
@@ -1,0 +1,53 @@
+package dev.soupslurpr.beautyxt.settings
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+class SettingsViewModel : ViewModel() {
+
+    /**
+     * Settings state
+     */
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    /**
+     * Populate the values of the settings from the Preferences DataStore.
+     * This function should only be called in Theme.kt when the app starts.
+     */
+    suspend fun populateSettingsFromDatastore(dataStore: DataStore<Preferences>) {
+        dataStore.data.map { settings ->
+            _uiState.update { currentState ->
+                currentState.copy(
+                    pitchBlackBackground = Pair(
+                            uiState.value.pitchBlackBackground.first,
+                            mutableStateOf(settings[uiState.value.pitchBlackBackground.first] ?: uiState.value.pitchBlackBackground.second.value)
+                    )
+                )
+            }
+        }.collect()
+    }
+
+    /**
+     * Set a setting to a value and save to Preferences DataStore
+     */
+    suspend fun setSetting(dataStore: DataStore<Preferences>, key: Preferences.Key<Boolean>, value: Boolean) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                pitchBlackBackground = if (uiState.value.pitchBlackBackground.first.name == key.name) {Pair(key, mutableStateOf(value))} else {uiState.value.pitchBlackBackground}
+            )
+        }
+        dataStore.edit { settings ->
+            settings[key] = value
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
@@ -37,7 +37,7 @@ fun FileEditScreen(
                 Text(
                     text = name
                 )
-            }
+            },
         )
     }
 }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -1,6 +1,8 @@
 package dev.soupslurpr.beautyxt.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -9,13 +11,25 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import dev.soupslurpr.beautyxt.R
+import dev.soupslurpr.beautyxt.settings.SettingsViewModel
+import kotlinx.coroutines.launch
 
 /**
  * Composable for settings screen
@@ -25,61 +39,86 @@ fun SettingsScreen(
     onLicenseIconButtonClicked: () -> Unit,
     onPrivacyPolicyIconButtonClicked: () -> Unit,
     onCreditsIconButtonClicked: () -> Unit,
+    settingsViewModel: SettingsViewModel,
+    dataStore: DataStore<Preferences>,
 ) {
     val localUriHandler = LocalUriHandler.current
+    val settingsUiState by settingsViewModel.uiState.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+
     Column(
-        modifier = Modifier.verticalScroll(rememberScrollState()),
+        modifier = Modifier
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        SettingsItem(
-            name = stringResource(id = R.string.view_source_code_setting_name),
-            description = stringResource(id = R.string.view_source_code_setting_description),
-            hasIconButton = true,
-            onClickIconButton = {
-                localUriHandler.openUri("https://github.com/soupslurpr/BeauTyXT")
-            },
-            iconButtonContent = {
-                Icon(
-                    imageVector = Icons.Filled.ExitToApp,
-                    contentDescription = stringResource(id = R.string.view_source_code_setting_description)
-                )
-            }
-        )
-        SettingsItem(
-            name = stringResource(id = R.string.license_setting_name),
-            description = stringResource(id = R.string.license_setting_description),
-            hasIconButton = true,
-            onClickIconButton = { onLicenseIconButtonClicked() },
-            iconButtonContent = {
-                Icon(
-                    imageVector = Icons.Filled.Info,
-                    contentDescription = stringResource(id = R.string.license_setting_description)
-                )
-            }
-        )
-        SettingsItem(
-            name = stringResource(id = R.string.privacy_policy_setting_name),
-            description = stringResource(id = R.string.privacy_policy_setting_description),
-            hasIconButton = true,
-            onClickIconButton = { onPrivacyPolicyIconButtonClicked() },
-            iconButtonContent = {
-                Icon(
-                    imageVector = Icons.Filled.Info,
-                    contentDescription = stringResource(id = R.string.privacy_policy_setting_description)
-                )
-            }
-        )
-        SettingsItem(
-            name = stringResource(id = R.string.credits_setting_name),
-            description = stringResource(id = R.string.credits_setting_description),
-            hasIconButton = true,
-            onClickIconButton = { onCreditsIconButtonClicked() },
-            iconButtonContent = {
-                Icon(
-                    imageVector = Icons.Filled.Info,
-                    contentDescription = stringResource(id = R.string.credits_setting_description)
-                )
-            }
-        )
+        Column {
+            SettingsCategoryText(category = stringResource(id = R.string.theme))
+            SettingsItem(
+                name = stringResource(id = R.string.pitch_black_background_setting_name),
+                description = stringResource(id = R.string.pitch_black_background_setting_description),
+                hasSwitch = true,
+                checked = settingsUiState.pitchBlackBackground.second.value,
+                onCheckedChange = {
+                    coroutineScope.launch {
+                        settingsViewModel.setSetting(dataStore, settingsUiState.pitchBlackBackground.first, it)
+                    }
+                }
+            )
+        }
+
+        Column {
+            SettingsCategoryText(category = stringResource(id = R.string.about))
+            SettingsItem(
+                name = stringResource(id = R.string.view_source_code_setting_name),
+                description = stringResource(id = R.string.view_source_code_setting_description),
+                hasIconButton = true,
+                onClickIconButton = {
+                    localUriHandler.openUri("https://github.com/soupslurpr/BeauTyXT")
+                },
+                iconButtonContent = {
+                    Icon(
+                        imageVector = Icons.Filled.ExitToApp,
+                        contentDescription = stringResource(id = R.string.view_source_code_setting_description)
+                    )
+                }
+            )
+            SettingsItem(
+                name = stringResource(id = R.string.license_setting_name),
+                description = stringResource(id = R.string.license_setting_description),
+                hasIconButton = true,
+                onClickIconButton = { onLicenseIconButtonClicked() },
+                iconButtonContent = {
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = stringResource(id = R.string.license_setting_description)
+                    )
+                }
+            )
+            SettingsItem(
+                name = stringResource(id = R.string.privacy_policy_setting_name),
+                description = stringResource(id = R.string.privacy_policy_setting_description),
+                hasIconButton = true,
+                onClickIconButton = { onPrivacyPolicyIconButtonClicked() },
+                iconButtonContent = {
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = stringResource(id = R.string.privacy_policy_setting_description)
+                    )
+                }
+            )
+            SettingsItem(
+                name = stringResource(id = R.string.credits_setting_name),
+                description = stringResource(id = R.string.credits_setting_description),
+                hasIconButton = true,
+                onClickIconButton = { onCreditsIconButtonClicked() },
+                iconButtonContent = {
+                    Icon(
+                        imageVector = Icons.Filled.Info,
+                        contentDescription = stringResource(id = R.string.credits_setting_description)
+                    )
+                }
+            )
+        }
     }
 }
 
@@ -92,18 +131,23 @@ fun SettingsItem(
     description: String,
     hasSwitch: Boolean = false,
     hasIconButton: Boolean = false,
-    onCheckedChange: () -> Unit = {},
+    onCheckedChange: (Boolean) -> Unit = {},
+    checked: Boolean = false,
     onClickIconButton: () -> Unit = {},
     iconButtonContent: @Composable () -> Unit = {},
 ) {
     ListItem(
-        headlineContent = { Text(text = name) },
+        headlineContent = {
+            Text(
+                text = name,
+                fontWeight = FontWeight.SemiBold
+            ) },
         supportingContent = { Text(text = description) },
         trailingContent = { 
             if (hasSwitch) {
                 Switch(
-                    checked = true,
-                    onCheckedChange = { onCheckedChange() }
+                    checked = checked,
+                    onCheckedChange = { onCheckedChange(it) },
                 ) 
             }
             if (hasIconButton) {
@@ -113,5 +157,17 @@ fun SettingsItem(
                 )
             }
         }
+    )
+}
+
+@Composable
+fun SettingsCategoryText(category: String) {
+    Text(
+        text = category,
+        textAlign = TextAlign.Center,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(8.dp),
+        style = typography.bodyMedium,
+        fontWeight = FontWeight.Bold
     )
 }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/StartupScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/StartupScreen.kt
@@ -72,8 +72,7 @@ fun StartupScreen(
         Text(
             text = "Text, but beautiful.\n" +
                     "\n" +
-                    "NEW! You can now open custom or any file type in BeauTyXT!\n" +
-                    "Just make sure they are plain text.",
+                    "Now includes actual settings!",
             style = MaterialTheme.typography.bodySmall,
             textAlign = TextAlign.Center
         )

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/theme/Theme.kt
@@ -2,15 +2,23 @@ package dev.soupslurpr.beautyxt.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import dev.soupslurpr.beautyxt.settings.SettingsViewModel
 
 /**
  * Dark color scheme for devices < Android 12, which do not support dynamic color.
@@ -25,19 +33,9 @@ private val DarkColorScheme = darkColorScheme(
  * Light color scheme for devices < Android 12, which do not support dynamic color.
  */
 private val LightColorScheme = lightColorScheme(
-    primary = Color.Blue,
+    primary = Purple40,
     secondary = PurpleGrey40,
     tertiary = Pink40,
-    background = Color(0xFFf5f5f5),
-    surface = Color(0xFFf5f5f5),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
-    primaryContainer = Color.White,
-    secondaryContainer = Color.White,
-    tertiaryContainer = Color.White,
 
     /* Other default colors to override
     background = Color(0xFFFFFBFE),
@@ -55,8 +53,17 @@ fun BeauTyXTTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
+    dataStore: DataStore<Preferences>,
+    settingsViewModel: SettingsViewModel = viewModel(),
     content: @Composable () -> Unit
 ) {
+
+    LaunchedEffect(key1 = Unit) {
+        settingsViewModel.populateSettingsFromDatastore(dataStore)
+    }
+
+    val settingsUiState by settingsViewModel.uiState.collectAsState()
+
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
@@ -68,27 +75,35 @@ fun BeauTyXTTheme(
     }
 
     val systemUiController = rememberSystemUiController()
+
+    val pitchBlackBackground = settingsUiState.pitchBlackBackground.second.value and darkTheme
+
+    val finalColorScheme: ColorScheme = colorScheme.copy(
+        background = if (pitchBlackBackground) {Color.Black} else {colorScheme.background},
+        surface = if (pitchBlackBackground) {Color.Black} else {colorScheme.surface}
+    )
+
     /**
      * Set the status bar and navigation bar colors to the background color of the app.
      */
     if (darkTheme) {
         systemUiController.setSystemBarsColor(
-            color = colorScheme.background
+            color = finalColorScheme.background
         )
         systemUiController.setNavigationBarColor(
-            color = colorScheme.background
+            color = finalColorScheme.background
         )
     } else {
         systemUiController.setSystemBarsColor(
-            color = colorScheme.background
+            color = finalColorScheme.background
         )
         systemUiController.setNavigationBarColor(
-            color = colorScheme.background
+            color = finalColorScheme.background
         )
     }
 
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = finalColorScheme,
         typography = Typography,
         content = content
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">BeauTyXT</string>
     <string name="settings">Settings</string>
     <string name="back_button">Back</string>
@@ -17,8 +17,12 @@
     <string name="credits">Credits</string>
     <string name="credits_setting_name">Credits</string>
     <string name="credits_setting_description">View open source licenses of code that BeauTyXT uses in app</string>
-    <string name="any">Any</string>
-    <string name="pick_a_file_type_to_create">Pick a file type to create</string>
-    <string name="pick_a_file_type_to_open">Pick a file type to open</string>
-    <string name="txt">Plain Text (.txt &amp; .text)</string>
+    <string name="any" tools:ignore="MissingTranslation">Any</string>
+    <string name="pick_a_file_type_to_create" tools:ignore="MissingTranslation">Pick a file type to create</string>
+    <string name="pick_a_file_type_to_open" tools:ignore="MissingTranslation">Pick a file type to open</string>
+    <string name="txt" tools:ignore="MissingTranslation">Plain Text (.txt &amp; .text)</string>
+    <string name="pitch_black_background_setting_name" tools:ignore="MissingTranslation">Pitch black background</string>
+    <string name="pitch_black_background_setting_description" tools:ignore="MissingTranslation">Replaces background with pitch black background when dark theme is on</string>
+    <string name="about" tools:ignore="MissingTranslation">About</string>
+    <string name="theme" tools:ignore="MissingTranslation">Theme</string>
 </resources>


### PR DESCRIPTION
Adds Settings infrastructure using preferences datastore.
Also adds the first setting, a pitch black background setting.

resolves #30 and resolves #31 
