### PR TITLE
Simplify population of settings at startup

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityOptionsCompat
-import androidx.datastore.core.DataStore
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -81,7 +80,6 @@ fun BeauTyXTApp(
     settingsViewModel: SettingsViewModel = viewModel(),
     modifier: Modifier,
     intent: Intent,
-    dataStore: DataStore<androidx.datastore.preferences.core.Preferences>
 ) {
     val navController = rememberNavController()
 
@@ -190,7 +188,6 @@ fun BeauTyXTApp(
                     onCreditsIconButtonClicked = {
                         navController.navigate(BeauTyXTScreens.Credits.name)
                     },
-                    dataStore = dataStore,
                     settingsViewModel = settingsViewModel
                 )
             }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -18,15 +18,17 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent() {
-            val settingsViewModel: SettingsViewModel = viewModel()
+            val settingsViewModel: SettingsViewModel = viewModel(
+                factory = SettingsViewModel.SettingsViewModelFactory(
+                    dataStore
+                )
+            )
             BeauTyXTTheme(
-                dataStore = dataStore,
                 settingsViewModel = settingsViewModel
             ) {
                 BeauTyXTApp(
                     modifier = Modifier,
                     intent = intent,
-                    dataStore = dataStore,
                     settingsViewModel = settingsViewModel
                 )
             }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import dev.soupslurpr.beautyxt.R
 import dev.soupslurpr.beautyxt.settings.SettingsViewModel
 import kotlinx.coroutines.launch
@@ -40,7 +38,6 @@ fun SettingsScreen(
     onPrivacyPolicyIconButtonClicked: () -> Unit,
     onCreditsIconButtonClicked: () -> Unit,
     settingsViewModel: SettingsViewModel,
-    dataStore: DataStore<Preferences>,
 ) {
     val localUriHandler = LocalUriHandler.current
     val settingsUiState by settingsViewModel.uiState.collectAsState()
@@ -60,7 +57,7 @@ fun SettingsScreen(
                 checked = settingsUiState.pitchBlackBackground.second.value,
                 onCheckedChange = {
                     coroutineScope.launch {
-                        settingsViewModel.setSetting(dataStore, settingsUiState.pitchBlackBackground.first, it)
+                        settingsViewModel.setSetting(settingsUiState.pitchBlackBackground.first, it)
                     }
                 }
             )

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/theme/Theme.kt
@@ -2,20 +2,16 @@ package dev.soupslurpr.beautyxt.ui.theme
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dev.soupslurpr.beautyxt.settings.SettingsViewModel
@@ -53,57 +49,66 @@ fun BeauTyXTTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
-    dataStore: DataStore<Preferences>,
     settingsViewModel: SettingsViewModel = viewModel(),
     content: @Composable () -> Unit
 ) {
 
-    LaunchedEffect(key1 = Unit) {
-        settingsViewModel.populateSettingsFromDatastore(dataStore)
-    }
-
     val settingsUiState by settingsViewModel.uiState.collectAsState()
+
+    val pitchBlackBackground = settingsUiState.pitchBlackBackground.second.value and darkTheme
 
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            if (darkTheme) {
+                if (pitchBlackBackground) {
+                    dynamicDarkColorScheme(context).copy(
+                        background = Color.Black,
+                        surface = Color.Black,
+                    )
+                } else {
+                    dynamicDarkColorScheme(context)
+                }
+            } else {
+                dynamicLightColorScheme(context)
+            }
         }
-
-        darkTheme -> DarkColorScheme
+        darkTheme -> {
+            if (pitchBlackBackground) {
+                DarkColorScheme.copy(
+                    background = Color.Black,
+                    surface = Color.Black
+                )
+            } else {
+                DarkColorScheme
+            }
+        }
         else -> LightColorScheme
     }
 
     val systemUiController = rememberSystemUiController()
-
-    val pitchBlackBackground = settingsUiState.pitchBlackBackground.second.value and darkTheme
-
-    val finalColorScheme: ColorScheme = colorScheme.copy(
-        background = if (pitchBlackBackground) {Color.Black} else {colorScheme.background},
-        surface = if (pitchBlackBackground) {Color.Black} else {colorScheme.surface}
-    )
 
     /**
      * Set the status bar and navigation bar colors to the background color of the app.
      */
     if (darkTheme) {
         systemUiController.setSystemBarsColor(
-            color = finalColorScheme.background
+            color = colorScheme.background
         )
         systemUiController.setNavigationBarColor(
-            color = finalColorScheme.background
+            color = colorScheme.background
         )
     } else {
         systemUiController.setSystemBarsColor(
-            color = finalColorScheme.background
+            color = colorScheme.background
         )
         systemUiController.setNavigationBarColor(
-            color = finalColorScheme.background
+            color = colorScheme.background
         )
     }
 
     MaterialTheme(
-        colorScheme = finalColorScheme,
+        colorScheme = colorScheme,
         typography = Typography,
         content = content
     )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.0-alpha09" apply false
+    id("com.android.application") version "8.2.0-alpha10" apply false
     id("org.jetbrains.kotlin.android") version "1.8.21" apply false
     id("com.google.devtools.ksp") version "1.8.21-1.0.11" apply false
 }


### PR DESCRIPTION
Simplify population of setting values at startup by doing it in the SettingViewModel's init instead of a LaunchedEffect in Theme.kt. 

Also we now pass dataStore to SettingsViewModel as a parameter when we create the SettingsViewModel in MainActivity, where we passed it to the rest of the app from there.