### PR TITLE
Rework opening files from intents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,19 +25,19 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:scheme="content"/>
-                <data android:mimeType="text/*"/>
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <data android:scheme="content"/>
-                <data android:mimeType="application/xml"/>
+                <data android:mimeType="text/plain"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:scheme="content"/>
                 <data android:mimeType="application/json"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:scheme="content"/>
+                <data android:mimeType="application/xml"/>
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -1,7 +1,5 @@
 package dev.soupslurpr.beautyxt
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
@@ -17,7 +15,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -29,6 +26,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navDeepLink
 import dev.soupslurpr.beautyxt.settings.SettingsViewModel
 import dev.soupslurpr.beautyxt.ui.CreditsScreen
 import dev.soupslurpr.beautyxt.ui.FileEditScreen
@@ -79,7 +77,6 @@ fun BeauTyXTApp(
     fileViewModel: FileViewModel = viewModel(),
     settingsViewModel: SettingsViewModel = viewModel(),
     modifier: Modifier,
-    intent: Intent,
 ) {
     val navController = rememberNavController()
 
@@ -104,16 +101,6 @@ fun BeauTyXTApp(
         if (it != null) {
             fileViewModel.setUri(it, context)
             navController.navigate(BeauTyXTScreens.FileEdit.name)
-        }
-    }
-
-    LaunchedEffect(key1 = Unit) {
-        if (intent.action == Intent.ACTION_VIEW || intent.action == Intent.ACTION_EDIT) {
-            val uri: Uri? = intent.data
-            if (uri != null) {
-                fileViewModel.setUri(uri, context)
-                navController.navigate(BeauTyXTScreens.FileEdit.name)
-            }
         }
     }
 
@@ -167,14 +154,27 @@ fun BeauTyXTApp(
                     }
                 )
             }
-            composable(route = BeauTyXTScreens.FileEdit.name) {
+            composable(
+                route = BeauTyXTScreens.FileEdit.name,
+                deepLinks = listOf(
+                    navDeepLink {
+                        mimeType = "text/plain"
+                    },
+                    navDeepLink {
+                        mimeType = "application/json"
+                    },
+                    navDeepLink {
+                        mimeType = "application/xml"
+                    }
+                ),
+            ) {
                 FileEditScreen(
-                    content = uiState.content.value,
-                    name = uiState.name,
+                    name = uiState.name.value,
                     onContentChanged = {
                         fileViewModel.updateContent(it)
                         fileViewModel.setContentToUri(uri = uiState.uri, context = context)
                     },
+                    content = uiState.content.value,
                 )
             }
             composable(route = BeauTyXTScreens.Settings.name) {

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -1,15 +1,18 @@
 package dev.soupslurpr.beautyxt
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.soupslurpr.beautyxt.settings.SettingsViewModel
+import dev.soupslurpr.beautyxt.ui.FileViewModel
 import dev.soupslurpr.beautyxt.ui.theme.BeauTyXTTheme
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
@@ -17,19 +20,20 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "se
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent() {
+        setContent {
             val settingsViewModel: SettingsViewModel = viewModel(
-                factory = SettingsViewModel.SettingsViewModelFactory(
-                    dataStore
-                )
+                factory = SettingsViewModel.SettingsViewModelFactory(dataStore)
             )
+            val fileViewModel: FileViewModel = viewModel()
+            if (intent.action == Intent.ACTION_VIEW) {
+                intent.data?.let { fileViewModel.setUri(it, LocalContext.current) }
+            }
             BeauTyXTTheme(
                 settingsViewModel = settingsViewModel
             ) {
                 BeauTyXTApp(
-                    modifier = Modifier,
-                    intent = intent,
-                    settingsViewModel = settingsViewModel
+                    settingsViewModel = settingsViewModel,
+                    modifier = Modifier
                 )
             }
         }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/data/FileUiState.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/data/FileUiState.kt
@@ -8,7 +8,7 @@ data class FileUiState(
     /** uri of file */
     val uri: Uri = Uri.EMPTY,
     /** name of file */
-    val name: String = "",
+    val name: MutableState<String> = mutableStateOf(""),
     /** content of file */
     var content: MutableState<String> = mutableStateOf(""),
     /** mimeType of file */

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 
 /**
  * Composable for editing text in a TextField,
@@ -40,10 +39,4 @@ fun FileEditScreen(
             },
         )
     }
-}
-
-@Preview
-@Composable
-fun FileEditPreview() {
-    FileEditScreen(content = "test", name = "test.txt")
 }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileViewModel.kt
@@ -39,7 +39,7 @@ class FileViewModel : ViewModel() {
         }
     }
 
-    private fun getNameFromUri(uri: Uri, context: Context): String {
+    private fun getNameFromUri(uri: Uri, context: Context): MutableState<String> {
         var name = ""
         val contentResolver = context.contentResolver
         // The query, because it only applies to a single document, returns only
@@ -57,7 +57,7 @@ class FileViewModel : ViewModel() {
                 name = it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
             }
         }
-        return name
+        return mutableStateOf(name)
     }
 
     private fun getContentFromUri(uri: Uri, context: Context): MutableState<String> {


### PR DESCRIPTION
This reworks the way we open a file from an intent to use deep links instead of a LaunchedEffect. Checking for an intent and saving its Uri to the FileViewModel is now done in MainActivity.kt's setContent composable.

Fixes #27 