### PR TITLE
Increase clickable area to full settings item instead of just icon/toggle

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -76,7 +76,7 @@ fun SettingsScreen(
                 iconButtonContent = {
                     Icon(
                         imageVector = Icons.Filled.ExitToApp,
-                        contentDescription = stringResource(id = R.string.open_beautyxt_website_setting_description)
+                        contentDescription = ""
                     )
                 }
             )
@@ -90,7 +90,7 @@ fun SettingsScreen(
                 iconButtonContent = {
                     Icon(
                         imageVector = Icons.Filled.ExitToApp,
-                        contentDescription = stringResource(id = R.string.view_source_code_setting_description)
+                        contentDescription = ""
                     )
                 }
             )
@@ -102,7 +102,7 @@ fun SettingsScreen(
                 iconButtonContent = {
                     Icon(
                         imageVector = Icons.Filled.Info,
-                        contentDescription = stringResource(id = R.string.license_setting_description)
+                        contentDescription = ""
                     )
                 }
             )
@@ -114,7 +114,7 @@ fun SettingsScreen(
                 iconButtonContent = {
                     Icon(
                         imageVector = Icons.Filled.Info,
-                        contentDescription = stringResource(id = R.string.privacy_policy_setting_description)
+                        contentDescription = ""
                     )
                 }
             )
@@ -126,7 +126,7 @@ fun SettingsScreen(
                 iconButtonContent = {
                     Icon(
                         imageVector = Icons.Filled.Info,
-                        contentDescription = stringResource(id = R.string.credits_setting_description)
+                        contentDescription = ""
                     )
                 }
             )

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package dev.soupslurpr.beautyxt.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -148,6 +149,14 @@ fun SettingsItem(
     iconButtonContent: @Composable () -> Unit = {},
 ) {
     ListItem(
+        modifier = Modifier.clickable(onClick = {
+            if (hasSwitch) {
+                onCheckedChange(!checked)
+            }
+            if (hasIconButton) {
+                onClickIconButton()
+            }
+        }),
         headlineContent = {
             Text(
                 text = name,


### PR DESCRIPTION
Now the whole item is clickable instead of just the icon/toggle. Also includes changes to make the contentDescription's of icons blank as the whole item is clickable (toggles didn't have contentDescripton's).