### PR TITLE
Make open any file type experimental

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -346,7 +346,8 @@ fun BeauTyXTApp(
                     onSettingsButtonClicked = {
                         navController.navigate(BeauTyXTScreens.Settings.name)
                     },
-                    fileViewModel = fileViewModel
+                    fileViewModel = fileViewModel,
+                    preferencesUiState = preferencesUiState,
                 )
             }
             composable(

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesUiState.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesUiState.kt
@@ -32,4 +32,13 @@ data class PreferencesUiState(
         (booleanPreferencesKey("EXPERIMENTAL_FEATURES")),
         mutableStateOf(false)
     ),
+
+    /** Experimental feature that shows the open files of any type button. It is an experimental
+     * feature as it currently corrupts some files such as but not limited to .pdf's, .odt's, and
+     * probably more.
+     */
+    val experimentalFeatureOpenAnyFileType: Pair<Preferences.Key<Boolean>, MutableState<Boolean>> = Pair(
+        (booleanPreferencesKey("EXPERIMENTAL_FEATURE_OPEN_ANY_FILE_TYPE")),
+        mutableStateOf(false)
+    )
 )

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesViewModel.kt
@@ -52,6 +52,10 @@ class PreferencesViewModel(private val dataStore: DataStore<Preferences>) : View
                         uiState.value.experimentalFeaturePreviewRenderedMarkdownInFullscreen.first,
                         mutableStateOf(settings[uiState.value.experimentalFeaturePreviewRenderedMarkdownInFullscreen.first] ?: uiState.value.experimentalFeaturePreviewRenderedMarkdownInFullscreen.second.value)
                     ),
+                    experimentalFeatureOpenAnyFileType = Pair(
+                        uiState.value.experimentalFeatureOpenAnyFileType.first,
+                        mutableStateOf(settings[uiState.value.experimentalFeatureOpenAnyFileType.first] ?: uiState.value.experimentalFeatureOpenAnyFileType.second.value)
+                    )
                 )
             }
         }.collect()
@@ -67,6 +71,8 @@ class PreferencesViewModel(private val dataStore: DataStore<Preferences>) : View
                 acceptedPrivacyPolicyAndLicense = if (uiState.value.acceptedPrivacyPolicyAndLicense.first.name == key.name) {Pair(key, mutableStateOf(value))} else {uiState.value.acceptedPrivacyPolicyAndLicense},
                 renderMarkdown = if (uiState.value.renderMarkdown.first.name == key.name) {Pair(key, mutableStateOf(value))} else {uiState.value.renderMarkdown},
                 experimentalFeaturePreviewRenderedMarkdownInFullscreen = if (uiState.value.experimentalFeaturePreviewRenderedMarkdownInFullscreen.first.name == key.name) {Pair(key, mutableStateOf(value))} else {uiState.value.experimentalFeaturePreviewRenderedMarkdownInFullscreen},
+                experimentalFeatureOpenAnyFileType = if (uiState.value.experimentalFeatureOpenAnyFileType.first.name == key.name) {Pair(key, mutableStateOf(value))} else {uiState.value.experimentalFeatureOpenAnyFileType},
+
             )
         }
         dataStore.edit { settings ->

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -92,6 +92,17 @@ fun SettingsScreen(
                     }
                 }
             )
+            SettingsItem(
+                name = stringResource(R.string.open_any_file_type_setting_name),
+                description = stringResource(R.string.open_any_file_type_setting_description),
+                hasSwitch = true,
+                checked = preferencesUiState.experimentalFeatureOpenAnyFileType.second.value,
+                onCheckedChange = {
+                    coroutineScope.launch {
+                        preferencesViewModel.setSetting(preferencesUiState.experimentalFeatureOpenAnyFileType.first, it)
+                    }
+                }
+            )
         }
 
         Column {

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/StartupScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/StartupScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.soupslurpr.beautyxt.R
+import dev.soupslurpr.beautyxt.settings.PreferencesUiState
 
 /**
  * Composable on startup that shows options like opening an existing file,
@@ -53,6 +54,7 @@ fun StartupScreen(
     onCreateMdButtonClicked: () -> Unit,
     onSettingsButtonClicked: () -> Unit,
     fileViewModel: FileViewModel,
+    preferencesUiState: PreferencesUiState,
 ) {
     var isOpenFileTypeAlertDialogShown by remember { mutableStateOf(false) }
     var isCreateFileTypeAlertDialogShown by remember { mutableStateOf(false) }
@@ -122,14 +124,16 @@ fun StartupScreen(
                 ) {
                     Text(text = stringResource(R.string.md))
                 }
-                FilledTonalButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    onClick = {
-                        onOpenAnyButtonClicked()
-                        isOpenFileTypeAlertDialogShown = false
+                if (preferencesUiState.experimentalFeatureOpenAnyFileType.second.value) {
+                    FilledTonalButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            onOpenAnyButtonClicked()
+                            isOpenFileTypeAlertDialogShown = false
+                        }
+                    ) {
+                        Text(text = stringResource(R.string.any))
                     }
-                ) {
-                    Text(text = stringResource(R.string.any))
                 }
             }
         }
@@ -226,6 +230,7 @@ fun StartupPreview() {
         onCreateTxtButtonClicked = {},
         onCreateMdButtonClicked = {},
         onSettingsButtonClicked = {},
-        fileViewModel = FileViewModel()
+        fileViewModel = FileViewModel(),
+        preferencesUiState = PreferencesUiState()
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
     <string name="experimental_features" tools:ignore="MissingTranslation">Experimental Features</string>
     <string name="fullscreen_markdown_render_preview_setting_name" tools:ignore="MissingTranslation">Fullscreen Markdown Render Preview</string>
     <string name="fullscreen_markdown_render_preview_setting_description" tools:ignore="MissingTranslation">Shows a button when a markdown file is open which will toggle a fullscreen view of the rendered markdown preview.\nExperimental because it has a few issues.</string>
+    <string name="open_any_file_type_setting_name" tools:ignore="MissingTranslation">Open Any File Type</string>
+    <string name="open_any_file_type_setting_description" tools:ignore="MissingTranslation">Shows Any file type option in the open an existing file dialog.\nWARNING PLEASE READ OR RISK LOSING DATA: This option currently corrupts some file types upon opening such as but not limited to pdf\'s, odt\'s, and probably others.</string>
 </resources>


### PR DESCRIPTION
This is because it was discovered that opening file types such as pdf's, odt's corrupts them. It probably happens to some other file types as well. 