### PR TITLE
Disable language splits temporarily

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,15 @@ android {
             signingConfig = signingConfigs.getByName("debug")
         }
     }
+    bundle {
+        language {
+            /** Disable splits for language for now since Accrescent does not support automatically
+             * fetching language splits when language is changed and instead needs a reinstall of hte app.
+             * Remove once Accrescent gets support.
+             */
+            enableSplit = false
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
 Disable splits for language for now since Accrescent does not support automatically fetching language splits when language is changed and instead needs a reinstall of hte app. Remove once Accrescent gets support.