### PR TITLE
Revert "Printing support for plain text"

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -209,19 +209,19 @@ fun BeauTyXTAppBar(
                     onDismissRequest = { onExportDropdownMenuDismissRequest() },
                     modifier = Modifier.width(225.dp)
                 ) {
-                    DropdownMenuItem(
-                        text = {
-                            Text(
-                                text = stringResource(R.string.print),
-                                style = dropDownMenuItemTextStyle
-                            )
-                        },
-                        onClick = { onPrintExportDropdownMenuItemClicked() },
-                        leadingIcon = {
-                            Icon(painter = painterResource(R.drawable.baseline_print_24), contentDescription = null)
-                        }
-                    )
                     if (mimeType == "text/markdown") {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    text = stringResource(R.string.print),
+                                    style = dropDownMenuItemTextStyle
+                                )
+                            },
+                            onClick = { onPrintExportDropdownMenuItemClicked() },
+                            leadingIcon = {
+                                Icon(painter = painterResource(R.drawable.baseline_print_24), contentDescription = null)
+                            }
+                        )
                         DropdownMenuItem(
                             text = {
                                 Text(
@@ -561,10 +561,8 @@ fun BeauTyXTApp(
                         }
                     }
 
-                    when (fileUiState.mimeType.value) {
-                        "text/markdown" -> {
-                            fileViewModel.setMarkdownToHtml()
-                            val htmlDocument = """
+                    fileViewModel.setMarkdownToHtml()
+                    val htmlDocument = """
                                 <!DOCTYPE html>
                                 <html>
                                     <head>
@@ -583,36 +581,8 @@ fun BeauTyXTApp(
                                         ${fileUiState.contentConvertedToHtml.value}
                                     </body>
                                 </html>
-                            """.trimIndent()
-                            webView.loadData(htmlDocument, "text/html", "UTF-8")
-                        }
-                        else -> {
-                            val htmlDocument = """
-                                <!DOCTYPE html>
-                                <html>
-                                    <head>
-                                        <meta charset="utf-8"/>
-                                        <meta name="viewport" content="width=device-width, initial-scale=1"/>
-                                        <style>
-                                            html {
-                                                overflow-wrap: anywhere;
-                                                white-space: pre-wrap;
-                                            }
-                                        </style>
-                                    </head>
-                                    <body>
-${
-                                fileUiState.content.value
-                                    .replace("&", "&amp;")
-                                    .replace("<", "&lt;")
-                                    .replace(">", "&gt;")
-                            }
-                                    </body>
-                                </html>
-                            """.trimIndent()
-                            webView.loadData(htmlDocument, "text/html", "UTF-8")
-                        }
-                    }
+                                """.trimIndent()
+                    webView.loadData(htmlDocument, "text/html", "UTF-8")
 
                     // Keep a reference to WebView object until you pass the PrintDocumentAdapter
                     // to the PrintManager

--- a/beautyxt_rs/useful-commands.txt
+++ b/beautyxt_rs/useful-commands.txt
@@ -22,5 +22,3 @@ Quick testing commands:
 
 cargo build --lib --release --target aarch64-linux-android
 copy .\target\aarch64-linux-android\release\libbeautyxt_rs.so ..\app\src\main\jniLibs\arm64-v8a\libbeautyxt_rs.so  
-
-cargo run --features uniffi/cli --bin uniffi-bindgen generate --library target/aarch64-linux-android/release/libbeautyxt_rs.so --language kotlin --out-dir "..\app\src\main\kotlin"


### PR DESCRIPTION
Reverts soupslurpr/BeauTyXT#95

Reason: Using # stops any characters after it from being seen in the print.