### PR TITLE
Plain text to docx support

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -471,14 +471,19 @@ fun BeauTyXTApp(
                             .fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(24.dp)
                     ) {
-                        SaveAsDialogItem(
-                            fileTypeText = stringResource(R.string.html),
-                            selected = saveAsSelectedFileType == mimeTypeHtml,
-                            onClickRadioButton = {
-                                saveAsSelectedFileType = mimeTypeHtml
-                            }
-                        )
-                        if (preferencesUiState.experimentalFeatureExportMarkdownToDocx.second.value) {
+                        if (fileUiState.mimeType.value == mimeTypeMarkdown) {
+                            SaveAsDialogItem(
+                                fileTypeText = stringResource(R.string.html),
+                                selected = saveAsSelectedFileType == mimeTypeHtml,
+                                onClickRadioButton = {
+                                    saveAsSelectedFileType = mimeTypeHtml
+                                }
+                            )
+                        }
+                        if ((preferencesUiState.experimentalFeatureExportMarkdownToDocx.second.value and
+                                    (fileUiState.mimeType.value == mimeTypeMarkdown)) or
+                            (fileUiState.mimeType.value != mimeTypeMarkdown)
+                        ) {
                             SaveAsDialogItem(
                                 fileTypeText = stringResource(R.string.docx),
                                 selected = saveAsSelectedFileType == mimeTypeDocx,

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -59,6 +59,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navDeepLink
+import dev.soupslurpr.beautyxt.constants.mimeTypeDocx
+import dev.soupslurpr.beautyxt.constants.mimeTypeHtml
+import dev.soupslurpr.beautyxt.constants.mimeTypeMarkdown
+import dev.soupslurpr.beautyxt.constants.mimeTypePlainText
 import dev.soupslurpr.beautyxt.settings.PreferencesUiState
 import dev.soupslurpr.beautyxt.settings.PreferencesViewModel
 import dev.soupslurpr.beautyxt.ui.CreditsScreen
@@ -142,7 +146,7 @@ fun BeauTyXTAppBar(
                 if (readOnly) {
                     Text(text = stringResource(R.string.read_only))
                 }
-                if (mimeType == "text/markdown") {
+                if (mimeType == mimeTypeMarkdown) {
                     if (preferencesUiState.experimentalFeaturePreviewRenderedMarkdownInFullscreen.second.value) {
                         IconButton(
                             onClick = onPreviewMarkdownRenderedToFullscreenButtonClicked,
@@ -337,7 +341,7 @@ fun BeauTyXTApp(
         }
     }
 
-    val createTxtFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument("text/plain")) {
+    val createTxtFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument(mimeTypePlainText)) {
         if (it != null) {
             fileViewModel.setReadOnly(false)
             fileViewModel.setUri(it, context)
@@ -345,7 +349,7 @@ fun BeauTyXTApp(
         }
     }
 
-    val createMdFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument("text/markdown")) {
+    val createMdFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument(mimeTypeMarkdown)) {
         if (it != null) {
             fileViewModel.setReadOnly(false)
             fileViewModel.setUri(it, context)
@@ -361,15 +365,11 @@ fun BeauTyXTApp(
 
     var saveAsShown by remember { mutableStateOf(false) }
 
-    val mimeTypeHtml = "text/html"
-
     val saveAsHtmlFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument(mimeTypeHtml)) {
         if (it != null) {
             fileViewModel.saveAsHtml(it, context)
         }
     }
-
-    val mimeTypeDocx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
     val saveAsDocxFileLauncher = rememberLauncherForActivityResult(contract = CreateDocument(mimeTypeDocx)) {
         if (it != null) {
@@ -560,7 +560,7 @@ fun BeauTyXTApp(
                     }
 
                     when (fileUiState.mimeType.value) {
-                        "text/markdown" -> {
+                        mimeTypeMarkdown -> {
                             fileViewModel.setMarkdownToHtml()
                             val htmlDocument = """
                                 <!DOCTYPE html>
@@ -582,7 +582,7 @@ fun BeauTyXTApp(
                                     </body>
                                 </html>
                             """.trimIndent()
-                            webView.loadData(htmlDocument, "text/html", "UTF-8")
+                            webView.loadData(htmlDocument, mimeTypeHtml, "UTF-8")
                         }
                         else -> {
                             val htmlDocument = """
@@ -610,7 +610,7 @@ ${
                                     </body>
                                 </html>
                             """.trimIndent()
-                            webView.loadData(htmlDocument, "text/html", "UTF-8")
+                            webView.loadData(htmlDocument, mimeTypeHtml, "UTF-8")
                         }
                     }
 
@@ -642,13 +642,13 @@ ${
                     splashMessage = splashMessage,
                     onOpenTxtButtonClicked = {
                         openFileLauncher.launch(
-                            arrayOf("text/plain"),
+                            arrayOf(mimeTypePlainText),
                             ActivityOptionsCompat.makeBasic(),
                         )
                     },
                     onOpenMdButtonClicked = {
                         openFileLauncher.launch(
-                            arrayOf("text/markdown"),
+                            arrayOf(mimeTypeMarkdown),
                             ActivityOptionsCompat.makeBasic(),
                         )
                     },
@@ -693,7 +693,7 @@ ${
                 route = BeauTyXTScreens.FileEdit.name,
                 deepLinks = listOf(
                     navDeepLink {
-                        mimeType = "text/plain"
+                        mimeType = mimeTypePlainText
                     },
                     navDeepLink {
                         mimeType = "application/json"
@@ -702,7 +702,7 @@ ${
                         mimeType = "application/xml"
                     },
                     navDeepLink {
-                        mimeType = "text/markdown"
+                        mimeType = mimeTypeMarkdown
                     }
                 ),
             ) {
@@ -712,7 +712,7 @@ ${
                         fileViewModel.updateContent(content)
                         fileViewModel.setContentToUri(uri = fileUiState.uri.value, context = context)
                         when (fileUiState.mimeType.value) {
-                            "text/markdown" -> if (preferencesUiState.renderMarkdown.second.value) {
+                            mimeTypeMarkdown -> if (preferencesUiState.renderMarkdown.second.value) {
                                 fileViewModel.setMarkdownToHtml()
                             }
                         }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -221,20 +221,18 @@ fun BeauTyXTAppBar(
                             Icon(painter = painterResource(R.drawable.baseline_print_24), contentDescription = null)
                         }
                     )
-                    if (mimeType == "text/markdown") {
-                        DropdownMenuItem(
-                            text = {
-                                Text(
-                                    text = stringResource(R.string.save_as),
-                                    style = dropDownMenuItemTextStyle
-                                )
-                            },
-                            onClick = { onSaveAsExportDropdownMenuItemClicked() },
-                            leadingIcon = {
-                                Icon(painter = painterResource(R.drawable.baseline_save_as_24), contentDescription = null)
-                            }
-                        )
-                    }
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                text = stringResource(R.string.save_as),
+                                style = dropDownMenuItemTextStyle
+                            )
+                        },
+                        onClick = { onSaveAsExportDropdownMenuItemClicked() },
+                        leadingIcon = {
+                            Icon(painter = painterResource(R.drawable.baseline_save_as_24), contentDescription = null)
+                        }
+                    )
                 }
                 if (saveAsShown) {
                     AlertDialog(

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/constants/MimeTypes.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/constants/MimeTypes.kt
@@ -1,0 +1,6 @@
+package dev.soupslurpr.beautyxt.constants
+
+const val mimeTypePlainText = "text/plain"
+const val mimeTypeMarkdown = "text/markdown"
+const val mimeTypeHtml = "text/html"
+const val mimeTypeDocx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileViewModel.kt
@@ -7,6 +7,7 @@ import android.provider.OpenableColumns
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import dev.soupslurpr.beautyxt.constants.mimeTypeMarkdown
 import dev.soupslurpr.beautyxt.data.FileUiState
 import dev.soupslurpr.beautyxt.markdownToDocx
 import dev.soupslurpr.beautyxt.markdownToHtml
@@ -227,7 +228,7 @@ class FileViewModel : ViewModel() {
     @OptIn(ExperimentalUnsignedTypes::class)
     fun saveAsDocx(uri: Uri, context: Context) {
         val docx = when (uiState.value.mimeType.value) {
-            "text/markdown" -> {
+            mimeTypeMarkdown -> {
                 markdownToDocx(uiState.value.content.value)
             }
 

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import dev.soupslurpr.beautyxt.data.FileUiState
 import dev.soupslurpr.beautyxt.markdownToDocx
 import dev.soupslurpr.beautyxt.markdownToHtml
+import dev.soupslurpr.beautyxt.plainTextToDocx
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -225,7 +226,15 @@ class FileViewModel : ViewModel() {
 
     @OptIn(ExperimentalUnsignedTypes::class)
     fun saveAsDocx(uri: Uri, context: Context) {
-        val docx = markdownToDocx(uiState.value.content.value)
+        val docx = when (uiState.value.mimeType.value) {
+            "text/markdown" -> {
+                markdownToDocx(uiState.value.content.value)
+            }
+
+            else -> {
+                plainTextToDocx(uiState.value.content.value)
+            }
+        }
 
         try {
             val contentResolver = context.contentResolver

--- a/beautyxt_rs/src/lib.rs
+++ b/beautyxt_rs/src/lib.rs
@@ -365,8 +365,11 @@ pub fn markdown_to_docx(markdown: String) -> Vec<u8> {
 
 #[uniffi::export]
 pub fn plain_text_to_docx(plain_text: String) -> Vec<u8> {
-    let docx = Docx::new()
-        .add_paragraph(docx_rs::Paragraph::new().add_run(Run::new().add_text(plain_text)));
+    let mut docx = Docx::new();
+
+    for paragraph in plain_text.split("\n") {
+        docx = docx.add_paragraph(docx_rs::Paragraph::new().add_run(Run::new().add_text(paragraph)))
+    }
 
     let mut buffer = Cursor::new(Vec::new());
 

--- a/beautyxt_rs/src/lib.rs
+++ b/beautyxt_rs/src/lib.rs
@@ -362,3 +362,15 @@ pub fn markdown_to_docx(markdown: String) -> Vec<u8> {
 
     buffer.into_inner()
 }
+
+#[uniffi::export]
+pub fn plain_text_to_docx(plain_text: String) -> Vec<u8> {
+    let docx = Docx::new()
+        .add_paragraph(docx_rs::Paragraph::new().add_run(Run::new().add_text(plain_text)));
+
+    let mut buffer = Cursor::new(Vec::new());
+
+    docx.build().pack(&mut buffer).unwrap();
+
+    buffer.into_inner()
+}


### PR DESCRIPTION
Adds support for exporting plain text (and any files opened using the open any file type option) to Office Open XML (.docx)

closes #98