### PR TITLE
Use enableEdgeToEdge instead of depreceated Accompanist system ui controller library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,6 @@ dependencies {
     implementation("androidx.compose.material:material")
     implementation("androidx.compose.material3:material3")
 
-    implementation("com.google.accompanist:accompanist-systemuicontroller:0.30.1")
     implementation("androidx.datastore:datastore-preferences:1.0.0")
     implementation("androidx.datastore:datastore-preferences:1.0.0")
     implementation("net.java.dev.jna:jna:5.13.0@aar")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
-    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.activity:activity-compose:1.8.0-rc01")
     implementation("androidx.navigation:navigation-compose:2.7.3")
     implementation("com.google.android.material:material:1.9.0")
 

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -22,6 +23,7 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "se
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/theme/Theme.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dev.soupslurpr.beautyxt.settings.PreferencesViewModel
 
 /**
@@ -51,7 +50,6 @@ fun BeauTyXTTheme(
     preferencesViewModel: PreferencesViewModel,
     content: @Composable () -> Unit
 ) {
-
     val settingsUiState by preferencesViewModel.uiState.collectAsState()
 
     val pitchBlackBackground = settingsUiState.pitchBlackBackground.second.value and darkTheme
@@ -83,27 +81,6 @@ fun BeauTyXTTheme(
             }
         }
         else -> LightColorScheme
-    }
-
-    val systemUiController = rememberSystemUiController()
-
-    /**
-     * Set the status bar and navigation bar colors to the background color of the app.
-     */
-    if (darkTheme) {
-        systemUiController.setSystemBarsColor(
-            color = colorScheme.background
-        )
-        systemUiController.setNavigationBarColor(
-            color = colorScheme.background
-        )
-    } else {
-        systemUiController.setSystemBarsColor(
-            color = colorScheme.background
-        )
-        systemUiController.setNavigationBarColor(
-            color = colorScheme.background
-        )
     }
 
     MaterialTheme(


### PR DESCRIPTION
The accompanist system ui controller library is depreceated. We can instead use the new enableEdgeToEdge function in androidx.activity:activity-compose for the same purpose we were using accompanist for.

Removes com.google.accompanist:accompanist-systemuicontroller as a dependency.