### PR TITLE
Use imePadding instead of android:windowSoftInputMode="adjustResize"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
         tools:targetApi="34">
         <activity
             android:name="dev.soupslurpr.beautyxt.MainActivity"
-            android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:theme="@style/Theme.beautyxt">
             <intent-filter>

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
@@ -5,6 +5,7 @@ import android.webkit.WebView
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -70,7 +71,7 @@ fun FileEditScreen(
     }
 
     Column(
-        modifier = Modifier
+        modifier = Modifier.imePadding()
     ) {
         TextField(
             /** We cannot use .verticalScroll when editing is possible as the TextField currently


### PR DESCRIPTION
With enableEdgeToEdge(), android:windowSoftInputMode="adjustResize" didn't seem to do anything anymore anyways. Applying imePadding seems to be the proper approach.