### PR TITLE
Bump dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,11 +70,11 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
-    implementation("androidx.activity:activity-compose:1.8.0-rc01")
-    implementation("androidx.navigation:navigation-compose:2.7.3")
-    implementation("com.google.android.material:material:1.9.0")
+    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation("androidx.navigation:navigation-compose:2.7.4")
+    implementation("com.google.android.material:material:1.10.0")
 
-    implementation(platform("androidx.compose:compose-bom:2023.09.02"))
+    implementation(platform("androidx.compose:compose-bom:2023.10.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")


### PR DESCRIPTION
androidx.activity:activity-compose:1.8.0-rc01 to 1.8.0
androidx.navigation:navigation-compose:2.7.3 to 2.7.4
com.google.android.material:material:1.9.0 to 1.10.0
androidx.compose:compose-bom:2023.09.02 to 2023.10.00