### PR TITLE
fixed `String` as a parameter type to `&str`

### DIFF
--- a/beautyxt_rs/src/plain_text.rs
+++ b/beautyxt_rs/src/plain_text.rs
@@ -2,7 +2,7 @@ use docx_rs::{Docx, Run};
 use std::io::Cursor;
 
 #[uniffi::export]
-pub fn plain_text_to_docx(plain_text: String) -> Vec<u8> {
+pub fn plain_text_to_docx(plain_text: &str) -> Vec<u8> {
     let mut docx = Docx::new();
 
     for paragraph in plain_text.split('\n') {


### PR DESCRIPTION
it is better to use `&str` rather than `String` as a parameter type.