### PR TITLE
Fix scoped storage permission issues causing a crash when opening a typst project folder that was not just created by the app (+ manual refresh for big documents + auto refresh onResume for cloud syncing + background preview refresh without freezing UI)

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="temurin-17" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,4 +97,6 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.1.0")
     implementation("net.java.dev.jna:jna:5.14.0@aar")
+
+    implementation("com.anggrayudi:storage:1.5.5")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:targetSandboxVersion="2">
+    
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -77,7 +77,6 @@ import com.anggrayudi.storage.file.DocumentFileCompat
 import com.anggrayudi.storage.file.FileFullPath
 import com.anggrayudi.storage.file.StorageId
 import com.anggrayudi.storage.file.getAbsolutePath
-//import com.anggrayudi.storage.file.makeFile
 import dev.soupslurpr.beautyxt.constants.mimeTypeDocx
 import dev.soupslurpr.beautyxt.constants.mimeTypeHtml
 import dev.soupslurpr.beautyxt.constants.mimeTypeMarkdown
@@ -1379,6 +1378,7 @@ ${
                                 typstProjectViewModel.bindService(projectFolder.uri)
                                 navController.navigate(BeauTyXTScreens.TypstProject.name)
                             }
+
                         // Second step
                         activity.storageHelper.onStorageAccessGranted =
                             { requestCode, root ->
@@ -1393,8 +1393,10 @@ ${
                                     )
                                 )
                             }
+                        
                         // First step, ask user to get Storage Access permission (this replaces the
                         // READ_STORAGE_PERMISSION of older Android versions)
+                        // TODO: This step is likely only necessary for Android 10 exactly (before there was no SAF, and later there is no difference between this call and folderpicker) - but I cannot test in an emulator right now so I prefer to make this step unconditional
                         Log.d("APP", "Ask user to get Storage Access permission")
                         activity.storageHelper.requestStorageAccess()
                         // Note that normally storageHelper.openFolderPicker should call

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -568,16 +568,6 @@ fun BeauTyXTApp(
         }
     }
 
-    val openTypstProjectLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts
-            .OpenDocumentTree()
-    ) { projectFolderUri ->
-        if (projectFolderUri != null) {
-            typstProjectViewModel.bindService(projectFolderUri)
-            navController.navigate(BeauTyXTScreens.TypstProject.name)
-        }
-    }
-
     val createTypstProjectLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts
             .OpenDocumentTree()

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/BeauTyXT.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
@@ -167,6 +168,7 @@ fun BeauTyXTAppBar(
     deleteFileDialogConfirmButton: @Composable () -> Unit,
     deleteFileDialogDismissButton: @Composable () -> Unit,
 
+    onTypstProjectRefreshButtonClicked: () -> Unit,
     onTypstProjectOpenAnotherFileInTheProjectButtonClicked: () -> Unit,
     onTypstProjectCreateAndOpenAnotherFileInTheProjectButtonClicked: () -> Unit,
 
@@ -225,6 +227,15 @@ fun BeauTyXTAppBar(
                             }
                         )
                     }
+                    IconButton(
+                        onClick = onTypstProjectRefreshButtonClicked,
+                        content = {
+                            Icon(
+                                imageVector = Icons.Filled.Refresh,
+                                contentDescription = stringResource(R.string.refresh)
+                            )
+                        }
+                    )
                     IconButton(
                         onClick = onTypstProjectCreateAndOpenAnotherFileInTheProjectButtonClicked,
                         content = {
@@ -618,6 +629,7 @@ fun BeauTyXTApp(
                 ()
     ) {
         if (it != null) {
+            Log.d("BeauTyXT", "setTypstCurrentOpenedPathLauncher: $it")
             typstProjectViewModel.refreshProjectFiles(context)
             typstProjectViewModel.setCurrentOpenedPath(it, context.contentResolver)
             typstProjectViewModel.setTypstProjectFileText(
@@ -1271,6 +1283,12 @@ ${
                     )
                 },
 
+                onTypstProjectRefreshButtonClicked = {
+                    // Refresh the Typst project files
+                    typstProjectViewModel.refreshProjectFiles(context)
+                    // Refresh the preview (SVG rendering)
+                    typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
+                },
                 onTypstProjectOpenAnotherFileInTheProjectButtonClicked = {
                     setTypstCurrentOpenedPathLauncher.launch(arrayOf("*/*"))
                 },

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -138,6 +138,13 @@ class MainActivity : ComponentActivity() {
         storageHelper.onRestoreInstanceState(savedInstanceState)
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        // Mandatory for direct subclasses of android.app.Activity,
+        // but not for subclasses of androidx.fragment.app.Fragment, androidx.activity.ComponentActivity, androidx.appcompat.app.AppCompatActivity
+        storageHelper.storage.onActivityResult(requestCode, resultCode, data)
+    }
+
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         // Restore scoped storage permission on Android 10+
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -35,13 +35,17 @@ class MainActivity : ComponentActivity() {
         setContent {
             val fileViewModel: FileViewModel = viewModel()
 
-            typstProjectViewModel = viewModel()
-
             val preferencesViewModel: PreferencesViewModel = viewModel(
                 factory = PreferencesViewModel.PreferencesViewModelFactory(dataStore)
             )
 
             val preferencesUiState by preferencesViewModel.uiState.collectAsState()
+
+            typstProjectViewModel = viewModel{
+                TypstProjectViewModel(
+                    application = application,
+                    preferencesViewModel = preferencesViewModel
+                )}
 
             val isActionViewOrEdit = (intent.action == Intent.ACTION_VIEW) or
                     (intent.action == Intent.ACTION_EDIT)

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/MainActivity.kt
@@ -20,10 +20,12 @@ import dev.soupslurpr.beautyxt.ui.FileViewModel
 import dev.soupslurpr.beautyxt.ui.ReviewPrivacyPolicyAndLicense
 import dev.soupslurpr.beautyxt.ui.TypstProjectViewModel
 import dev.soupslurpr.beautyxt.ui.theme.BeauTyXTTheme
+import com.anggrayudi.storage.SimpleStorageHelper
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 class MainActivity : ComponentActivity() {
+    val storageHelper = SimpleStorageHelper(this) // for scoped storage permission management on Android 10+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
@@ -88,6 +90,7 @@ class MainActivity : ComponentActivity() {
                     ReviewPrivacyPolicyAndLicense(preferencesViewModel = preferencesViewModel)
                 } else if (preferencesUiState.acceptedPrivacyPolicyAndLicense.second.value) {
                     BeauTyXTApp(
+                        activity = this@MainActivity, // provide the parent, MainActivity
                         modifier = Modifier,
                         fileViewModel = fileViewModel,
                         typstProjectViewModel = typstProjectViewModel,
@@ -98,5 +101,24 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        // Save scoped storage permission on Android 10+
+        storageHelper.onSaveInstanceState(outState)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        // Restore scoped storage permission on Android 10+
+        super.onRestoreInstanceState(savedInstanceState)
+        storageHelper.onRestoreInstanceState(savedInstanceState)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        // Restore scoped storage permission on Android 10+
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        // Mandatory for Activity, but not for Fragment & ComponentActivity
+        storageHelper.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesUiState.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesUiState.kt
@@ -31,9 +31,9 @@ data class PreferencesUiState(
         mutableStateOf(true)
     ),
 
-    /** Automatically refresh the render of the preview on typing (can be slow on big documents)
+    /** Automatically refresh the render of the preview on typing and on project loading (can be slow on big documents)
      */
-    val autoPreviewOnTyping: Pair<Preferences.Key<Boolean>, MutableState<Boolean>> = Pair(
+    val autoPreviewRefresh: Pair<Preferences.Key<Boolean>, MutableState<Boolean>> = Pair(
         (booleanPreferencesKey("AUTO_PREVIEW_ON_TYPING")),
         mutableStateOf(true)
     ),

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesUiState.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesUiState.kt
@@ -31,6 +31,13 @@ data class PreferencesUiState(
         mutableStateOf(true)
     ),
 
+    /** Automatically refresh the render of the preview on typing (can be slow on big documents)
+     */
+    val autoPreviewOnTyping: Pair<Preferences.Key<Boolean>, MutableState<Boolean>> = Pair(
+        (booleanPreferencesKey("AUTO_PREVIEW_ON_TYPING")),
+        mutableStateOf(true)
+    ),
+
     /** Experimental feature that shows a button when a markdown file is open which will toggle
      * a fullscreen view of the rendered markdown preview.
      */

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesViewModel.kt
@@ -64,6 +64,13 @@ class PreferencesViewModel(private val dataStore: DataStore<Preferences>) : View
                                 .typstProjectShowWarningsAndErrors.second.value
                         )
                     ),
+                    autoPreviewOnTyping = Pair(
+                        uiState.value.autoPreviewOnTyping.first,
+                        mutableStateOf(
+                            settings[uiState.value.autoPreviewOnTyping.first] ?: uiState.value.autoPreviewOnTyping
+                                .second.value
+                        )
+                    ),
                     experimentalFeaturePreviewRenderedMarkdownInFullscreen = Pair(
                         uiState.value.experimentalFeaturePreviewRenderedMarkdownInFullscreen.first,
                         mutableStateOf(

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/settings/PreferencesViewModel.kt
@@ -64,10 +64,10 @@ class PreferencesViewModel(private val dataStore: DataStore<Preferences>) : View
                                 .typstProjectShowWarningsAndErrors.second.value
                         )
                     ),
-                    autoPreviewOnTyping = Pair(
-                        uiState.value.autoPreviewOnTyping.first,
+                    autoPreviewRefresh = Pair(
+                        uiState.value.autoPreviewRefresh.first,
                         mutableStateOf(
-                            settings[uiState.value.autoPreviewOnTyping.first] ?: uiState.value.autoPreviewOnTyping
+                            settings[uiState.value.autoPreviewRefresh.first] ?: uiState.value.autoPreviewRefresh
                                 .second.value
                         )
                     ),

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -106,17 +106,17 @@ fun SettingsScreen(
                 }
             )
             SettingsItem(
-                name = stringResource(R.string.auto_preview_on_typing_setting_name),
+                name = stringResource(R.string.typst_project_auto_preview_setting_name),
                 description = stringResource(
-                    R.string.auto_preview_on_typing_setting_description,
+                    R.string.typst_project_auto_preview_setting_description,
                     stringResource(R.string.typst_project)
                 ),
                 hasSwitch = true,
-                checked = preferencesUiState.autoPreviewOnTyping.second.value,
+                checked = preferencesUiState.autoPreviewRefresh.second.value,
                 onCheckedChange = {
                     coroutineScope.launch {
                         preferencesViewModel.setPreference(
-                            preferencesUiState.autoPreviewOnTyping
+                            preferencesUiState.autoPreviewRefresh
                                 .first, it
                         )
                     }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/SettingsScreen.kt
@@ -105,6 +105,23 @@ fun SettingsScreen(
                     }
                 }
             )
+            SettingsItem(
+                name = stringResource(R.string.auto_preview_on_typing_setting_name),
+                description = stringResource(
+                    R.string.auto_preview_on_typing_setting_description,
+                    stringResource(R.string.typst_project)
+                ),
+                hasSwitch = true,
+                checked = preferencesUiState.autoPreviewOnTyping.second.value,
+                onCheckedChange = {
+                    coroutineScope.launch {
+                        preferencesViewModel.setPreference(
+                            preferencesUiState.autoPreviewOnTyping
+                                .first, it
+                        )
+                    }
+                }
+            )
         }
 
         Column {

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectScreen.kt
@@ -90,7 +90,9 @@ fun TypstProjectScreen(
 
                 typstProjectViewModel.updateProjectFileWithNewText(it, currentOpenedPath)
 
-                typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
+                if (preferencesUiState.autoPreviewOnTyping.second.value) {
+                    typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
+                }
             }
 
             Column(
@@ -151,7 +153,9 @@ fun TypstProjectScreen(
 
                 typstProjectViewModel.updateProjectFileWithNewText(it, currentOpenedPath)
 
-                typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
+                if (preferencesUiState.autoPreviewOnTyping.second.value) {
+                    typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
+                }
             }
 
             Column(

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectScreen.kt
@@ -90,7 +90,8 @@ fun TypstProjectScreen(
 
                 typstProjectViewModel.updateProjectFileWithNewText(it, currentOpenedPath)
 
-                if (preferencesUiState.autoPreviewOnTyping.second.value) {
+                // Refresh preview render on typing
+                if (preferencesUiState.autoPreviewRefresh.second.value) {
                     typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
                 }
             }
@@ -153,7 +154,8 @@ fun TypstProjectScreen(
 
                 typstProjectViewModel.updateProjectFileWithNewText(it, currentOpenedPath)
 
-                if (preferencesUiState.autoPreviewOnTyping.second.value) {
+                // Refresh preview render on typing
+                if (preferencesUiState.autoPreviewRefresh.second.value) {
                     typstProjectViewModel.renderProjectToSvgs(typstProjectViewModel.rustService!!)
                 }
             }

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
@@ -391,7 +391,7 @@ class TypstProjectViewModel(application: Application) : AndroidViewModel(applica
                     "Failed to call clearTypstProjectFiles(), might have already cleared as service is dead $e"
                 )
             }
-            //stopAndUnbindService()
+            stopAndUnbindService()
         }
     }
 

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
@@ -30,8 +30,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.FileOutputStream
-import com.anggrayudi.storage.SimpleStorageHelper
-import com.anggrayudi.storage.file.*
 
 private const val TAG = "TypstProjectViewModel"
 

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
@@ -25,6 +25,7 @@ import dev.soupslurpr.beautyxt.beautyxt_rs_typst_bindings.TypstCustomSourceDiagn
 import dev.soupslurpr.beautyxt.beautyxt_rs_typst_bindings.TypstCustomTracepoint
 import dev.soupslurpr.beautyxt.data.TypstProjectUiState
 import dev.soupslurpr.beautyxt.returnHashSha256
+import dev.soupslurpr.beautyxt.settings.PreferencesViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -33,7 +34,7 @@ import java.io.FileOutputStream
 
 private const val TAG = "TypstProjectViewModel"
 
-class TypstProjectViewModel(application: Application) : AndroidViewModel(application) {
+class TypstProjectViewModel(application: Application, val preferencesViewModel: PreferencesViewModel) : AndroidViewModel(application) {
 
     /**
      * File state for this file
@@ -94,7 +95,7 @@ class TypstProjectViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
-    fun openProject(context: Context) {
+    fun openProject(context: Context, refreshPreview: Boolean = true) {
         viewModelScope.launch {
             val files: MutableList<PathAndPfd> = mutableListOf()
             val filesQueue = ArrayDeque<DocumentFile>()
@@ -186,7 +187,10 @@ class TypstProjectViewModel(application: Application) : AndroidViewModel(applica
                 rustService!!.addTypstProjectFiles(files)
             }
 
-            renderProjectToSvgs(rustService!!)
+            // Refresh the preview render on project loading, but only if the user has enabled it
+            if (preferencesViewModel.uiState.value.autoPreviewRefresh.second.value) {
+                renderProjectToSvgs(rustService!!)
+            }
         }
     }
 

--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/TypstProjectViewModel.kt
@@ -26,10 +26,12 @@ import dev.soupslurpr.beautyxt.beautyxt_rs_typst_bindings.TypstCustomTracepoint
 import dev.soupslurpr.beautyxt.data.TypstProjectUiState
 import dev.soupslurpr.beautyxt.returnHashSha256
 import dev.soupslurpr.beautyxt.settings.PreferencesViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.FileOutputStream
 
 private const val TAG = "TypstProjectViewModel"
@@ -216,81 +218,85 @@ class TypstProjectViewModel(application: Application, val preferencesViewModel: 
         viewModelScope.launch {
             var noException = true
 
-            val bundle = rustService.getTypstSvg()
+            withContext(Dispatchers.IO) {  // Offload to a background thread because the computation for big documents can be heavy and freeze the whole UI
+                val bundle = rustService.getTypstSvg()
 
-            val svg = bundle.getByteArray("svg")
+                val svg = bundle.getByteArray("svg")
 
-            if (svg != null) {
-                _uiState.value.renderedProjectSvg.value = svg
-            } else {
-                var sourceDiagnostics: MutableList<TypstCustomSourceDiagnostic> = mutableStateListOf()
+                if (svg != null) {
+                    _uiState.value.renderedProjectSvg.value = svg
+                } else {
+                    var sourceDiagnostics: MutableList<TypstCustomSourceDiagnostic> =
+                        mutableStateListOf()
 
-                var index = 0
-                while (true) {
-                    val severity = bundle.getString("severity$index")
-                    val span = if (bundle.containsKey("span$index")) {
-                        bundle.getLong("span$index")
-                    } else {
-                        null
-                    }
-                    val message = bundle.getString("message$index")
-                    val trace = bundle.getInt("trace$index")
-
-                    val sourceDiagnostic = TypstCustomSourceDiagnostic(
-                        severity = when (severity) {
-                            "WARNING" -> TypstCustomSeverity.WARNING
-                            "ERROR" -> TypstCustomSeverity.ERROR
-                            else -> break
-                        },
-                        span = when (span) {
-                            null -> break
-                            else -> span.toULong()
-                        },
-                        message = when (message) {
-                            null -> break
-                            else -> message
-                        },
-                        trace = if (trace >= 0) {
-                            val traceList: MutableList<TypstCustomTracepoint> = mutableListOf()
-                            trace.downTo(0).reversed().forEach { traceIndex ->
-                                val prefix = "trace${index}name${traceIndex}"
-                                traceList.add(
-                                    when (bundle.getString(prefix)) {
-                                        "Call" -> TypstCustomTracepoint.Call(
-                                            string = bundle.getString("${prefix}string"),
-                                            span = bundle.getLong("${prefix}span").toULong(),
-                                        )
-
-                                        "Import" -> TypstCustomTracepoint.Import(
-                                            bundle.getLong("${prefix}span").toULong()
-                                        )
-
-                                        "Show" -> TypstCustomTracepoint.Show(
-                                            bundle.getString("${prefix}string") ?: return@forEach,
-                                            bundle.getLong("${prefix}span").toULong()
-                                        )
-
-                                        null -> return@forEach
-                                        else -> return@forEach
-                                    }
-                                )
-                            }
-                            traceList
+                    var index = 0
+                    while (true) {
+                        val severity = bundle.getString("severity$index")
+                        val span = if (bundle.containsKey("span$index")) {
+                            bundle.getLong("span$index")
                         } else {
-                            listOf()
-                        },
-                        hints = bundle.getStringArrayList("hints$index").let {
-                            it ?: ArrayList()
+                            null
                         }
-                    )
-                    sourceDiagnostics.add(sourceDiagnostic)
+                        val message = bundle.getString("message$index")
+                        val trace = bundle.getInt("trace$index")
 
-                    index += 1
+                        val sourceDiagnostic = TypstCustomSourceDiagnostic(
+                            severity = when (severity) {
+                                "WARNING" -> TypstCustomSeverity.WARNING
+                                "ERROR" -> TypstCustomSeverity.ERROR
+                                else -> break
+                            },
+                            span = when (span) {
+                                null -> break
+                                else -> span.toULong()
+                            },
+                            message = when (message) {
+                                null -> break
+                                else -> message
+                            },
+                            trace = if (trace >= 0) {
+                                val traceList: MutableList<TypstCustomTracepoint> = mutableListOf()
+                                trace.downTo(0).reversed().forEach { traceIndex ->
+                                    val prefix = "trace${index}name${traceIndex}"
+                                    traceList.add(
+                                        when (bundle.getString(prefix)) {
+                                            "Call" -> TypstCustomTracepoint.Call(
+                                                string = bundle.getString("${prefix}string"),
+                                                span = bundle.getLong("${prefix}span").toULong(),
+                                            )
+
+                                            "Import" -> TypstCustomTracepoint.Import(
+                                                bundle.getLong("${prefix}span").toULong()
+                                            )
+
+                                            "Show" -> TypstCustomTracepoint.Show(
+                                                bundle.getString("${prefix}string")
+                                                    ?: return@forEach,
+                                                bundle.getLong("${prefix}span").toULong()
+                                            )
+
+                                            null -> return@forEach
+                                            else -> return@forEach
+                                        }
+                                    )
+                                }
+                                traceList
+                            } else {
+                                listOf()
+                            },
+                            hints = bundle.getStringArrayList("hints$index").let {
+                                it ?: ArrayList()
+                            }
+                        )
+                        sourceDiagnostics.add(sourceDiagnostic)
+
+                        index += 1
+                    }
+
+                    _uiState.value.sourceDiagnostics.clear()
+                    _uiState.value.sourceDiagnostics.addAll(sourceDiagnostics)
+                    noException = false
                 }
-
-                _uiState.value.sourceDiagnostics.clear()
-                _uiState.value.sourceDiagnostics.addAll(sourceDiagnostics)
-                noException = false
             }
 
             if (noException) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,8 +88,8 @@
     <string name="create_and_edit_another_file_in_the_typst_project" tools:ignore="MissingTranslation">Create and edit another file in the Typst project</string>
     <string name="typst_project_show_warnings_and_errors_setting_name" tools:ignore="MissingTranslation">Show warnings and errors</string>
     <string name="typst_project_show_warnings_and_errors_setting_description" tools:ignore="MissingTranslation">Show warnings and errors below the %1$s preview</string>
-    <string name="auto_preview_on_typing_setting_name" tools:ignore="MissingTranslation">Auto update the preview on typing</string>
-    <string name="auto_preview_on_typing_setting_description" tools:ignore="MissingTranslation">Refresh the render after each character input (slow for big documents), otherwise you will need to refresh manually</string>
+    <string name="typst_project_auto_preview_setting_name" tools:ignore="MissingTranslation">Auto update the preview</string>
+    <string name="typst_project_auto_preview_setting_description" tools:ignore="MissingTranslation">Refresh the render on typing any character and on project loading (slow for big documents), otherwise you will need to refresh manually</string>
     <string name="rendered_typst_project_preview" tools:ignore="MissingTranslation">Rendered Typst project preview</string>
     <string name="toggle_previewing_typst_project_in_fullscreen" tools:ignore="MissingTranslation">Toggle previewing Typst project in fullscreen</string>
     <string name="fullscreen_typst_preview_button_setting_name" tools:ignore="MissingTranslation">Fullscreen Typst Preview Button</string>
@@ -100,5 +100,5 @@
     <string name="view_credits_for_rust_library_for_plain_text_and_markdown_support" tools:ignore="MissingTranslation">View Credits for Rust library for Plain Text and Markdown support</string>
     <string name="view_credits_for_rust_library_for_typst_support" tools:ignore="MissingTranslation">View Credits for Rust library for Typst support</string>
     <string name="typst_rust_library_credits" translatable="false">Typst Rust Library Credits</string>
-    <string name="refresh">Refresh</string>
+    <string name="refresh" tools:ignore="MissingTranslation">Refresh</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="create_and_edit_another_file_in_the_typst_project" tools:ignore="MissingTranslation">Create and edit another file in the Typst project</string>
     <string name="typst_project_show_warnings_and_errors_setting_name" tools:ignore="MissingTranslation">Show warnings and errors</string>
     <string name="typst_project_show_warnings_and_errors_setting_description" tools:ignore="MissingTranslation">Show warnings and errors below the %1$s preview</string>
+    <string name="auto_preview_on_typing_setting_name" tools:ignore="MissingTranslation">Auto update the preview on typing</string>
+    <string name="auto_preview_on_typing_setting_description" tools:ignore="MissingTranslation">Refresh the render after each character input (slow for big documents), otherwise you will need to refresh manually</string>
     <string name="rendered_typst_project_preview" tools:ignore="MissingTranslation">Rendered Typst project preview</string>
     <string name="toggle_previewing_typst_project_in_fullscreen" tools:ignore="MissingTranslation">Toggle previewing Typst project in fullscreen</string>
     <string name="fullscreen_typst_preview_button_setting_name" tools:ignore="MissingTranslation">Fullscreen Typst Preview Button</string>
@@ -97,5 +99,6 @@
     <string name="donation_setting_description" tools:ignore="MissingTranslation">View how to donate to BeauTyXT\'s lead developer in-app</string>
     <string name="view_credits_for_rust_library_for_plain_text_and_markdown_support" tools:ignore="MissingTranslation">View Credits for Rust library for Plain Text and Markdown support</string>
     <string name="view_credits_for_rust_library_for_typst_support" tools:ignore="MissingTranslation">View Credits for Rust library for Typst support</string>
-    <string name="typst_rust_library_credits">Typst Rust Library Credits</string>
+    <string name="typst_rust_library_credits" translatable="false">Typst Rust Library Credits</string>
+    <string name="refresh">Refresh</string>
 </resources>


### PR DESCRIPTION
Before this fix, creating a folder worked fine, but accessing an already existing folder crashed. The only exception is when we create a folder, and then try to reopen it just after. But once we erase the app's cache, or reinstall it, or create another folder, then trying to open the previously created folder will crash, just like for any other folder.

This is because of scoped storage limitations introduced in Android 10+. An app can freely create a folder, and access all files inside (files are then considered as "media" files, and the folder a media database of resources), but this is only temporary: the access to this "media" folder will be lost once the app requests the access to another folder or is reinstalled or its cache is erased. This is exactly what happened here.

The solution is to go through the hoops of the scoped storage new system to ask specifically to access an already existing folder and then ask for a permission to write in it. The functions all changed and it's very complicated to get it right.

Fortunately, there is the [SimpleStorage](https://github.com/anggrayudi/SimpleStorage) library. I implented it here only to open already existing Typst folders, the biggest issue currently IMHO.

The same fix should be applied to creating a Typst folder (although it works currently, the folder is created with the improper method, as a "media" collection instead of being just a raw folder of files - in practice it doesn't change much in this case I think but to be more future-proof it would be better to also use SimpleStorage for creation too) ; and also the fix should be applied to opening files. I did not try to open markdown files because I am using another editor for this purpose, but I guess the same issue will arise.

This PR may also be unclean, I did it very roughly and quickly as I am currently lacking time, it's more a proof of concept than a polished implementation, so please feel free to cherry pick and edit as you see fit.

Note that it includes additional edits than the scoped storage fix (all the changes in TypstProjectViewModel.kt were made prior to try to make rustService more robust against crashes or more explicit with log messages, you can keep or remove as you prefer).

Fixes #149

For those who want to try the debug apk: https://github.com/lrq3000/BeauTyXT/releases/tag/scoped-storage-fix4-and-background-refresh

/EDIT: Since I aim to use this app to write my whole PhD thesis, I am going to use it extensively on a daily basis. I added a few other features:

1. another feature that I think is necessary, the ability to disable the automatic preview refresh, and added a manual refresh button in the top toolbar. This allows to work on documents that are bigger than toy examples, otherwise they are way too slow after each typed character since there is a refresh, whereas here we can refresh only when we want.
    * Note: Also the manual refresh doubles as a way to manually force a refresh after syncing the files (eg with syncthing), whereas before it was necessary to type in the current document to force the refresh (note that it does NOT refresh the edited text, but only the preview and list of files, to refresh the edited text, it's still necessary to reopen the current file, this is done because otherwise it would be surprising for the user that the refresh button may change their whole inputs!).
2. onResume() is now implemented to auto refresh the content in the text editor when the app regains focus. Essentially this means that when the app in the background or the screen is turned off, and there is a background cloud files synchronization service that updates the files (such as Syncthing or Dropbox), then when the app regains focus, the latest version of the file will be displayed. This avoids overwriting newer changes with an older version by mistake (eases multidevices synchronization).
    * Note: a better implementation would be an explicit detection of changes in the background (difference between current value in the app versus the file's content) and ask the user what to do, but the implementation I propose is much easier and works for 80% of cases.
3. renderProjectToSvgs(), which manages the preview refresh for Typst projects, is now launched in a background process and with a mutex lock to avoid multiple calls in parallel which can crash the app (eg, auto refresh on typing, with a user who types fast!). This avoids non toy Typst projects from freezing the whole app during preview refreshes, so now the user can type and even open other files in the project while the preview is smoothly updated in the background. This kind of removes the need for the manual refresh, but I keep it because it can still be useful for those who want to save on battery or for when the files are edited from outside the app.

TODO:
- [x] Test all features on a real phone.
- [x] Test on Android 10 (API 29) (real phone, ARM64)
- [ ] Test on Android 14 (API 34) (emulated) -- could not test because emulator requires compiling the libraries for x86_64