### PR TITLE
Use Material You colors for links in Markdown preview (#153)

### DIFF
--- a/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
+++ b/app/src/main/kotlin/dev/soupslurpr/beautyxt/ui/FileEditScreen.kt
@@ -217,6 +217,15 @@ fun FileEditScreen(
                                             table, th, td {
                                                 border: thin solid;
                                             }
+                                            a:link {
+                                                color: ${colorScheme.primary.toCssColor()}
+                                            }
+                                            a:visited {
+                                                color: ${colorScheme.secondary.toCssColor()}
+                                            }
+                                            a:hover {
+                                                color: ${colorScheme.tertiary.toCssColor()}
+                                            }
                                         </style>
                                     </head>
                                     <body>
@@ -372,6 +381,15 @@ fun FileEditScreen(
                                             }
                                             table, th, td {
                                                 border: thin solid;
+                                            }
+                                            a:link {
+                                                color: ${colorScheme.primary.toCssColor()}
+                                            }
+                                            a:visited {
+                                                color: ${colorScheme.secondary.toCssColor()}
+                                            }
+                                            a:hover {
+                                                color: ${colorScheme.tertiary.toCssColor()}
                                             }
                                         </style>
                                     </head>


### PR DESCRIPTION
Fixes an accessibility issue since the default link color may not provide enough contrast with some Material You backgrounds.

Resolves #153 