### PR TITLE
Fix dead CONTRIBUTING.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Check out the official website at https://beautyxt.app/ for more info and downlo
 
 ## Contributing
 
-Check [CONTRIBUTING.md](https://github.com/soupslurpr/BeauTyXT/blob/master/CONTRIBUTING.md) for things to know
+Check [CONTRIBUTING.md](./CONTRIBUTING.md) for things to know
 if you want to contribute. Also points to build instructions.
 
 ## Donation


### PR DESCRIPTION
The CONTRIBUTING.md link is dead.
It was an absolute HTTPS URL referring to the master branch which isn't used anymore.